### PR TITLE
feat: add click-to-copy functionality for entity table values

### DIFF
--- a/src/lib/components/ui/copyable-text/copyable-text.svelte
+++ b/src/lib/components/ui/copyable-text/copyable-text.svelte
@@ -1,0 +1,91 @@
+<script>
+    import * as Tooltip from "$src/lib/components/ui/tooltip";
+    import { toast } from "svelte-sonner";
+
+    let { 
+        value = '',
+        truncate = true,
+        showToast = true,
+        successMessage = 'Copied to clipboard'
+    } = $props();
+
+    let copied = $state(false);
+
+    async function copyToClipboard() {
+        if (!value || value === '-') return;
+        
+        try {
+            await navigator.clipboard.writeText(value);
+            copied = true;
+            if (showToast) {
+                toast.success(successMessage, {
+                    description: value
+                });
+            }
+            
+            setTimeout(() => {
+                copied = false;
+            }, 1000);
+        } catch (err) {
+            console.error('Failed to copy:', err);
+        }
+    }
+</script>
+
+<Tooltip.Root>
+    <Tooltip.Trigger>
+        <button 
+            class="copyable-text" 
+            class:truncated={truncate}
+            class:copied={copied}
+            onclick={copyToClipboard}
+            type="button"
+        >
+            {value || '-'}
+        </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>
+        <p>{copied ? '✓ Copied!' : value || '-'}</p>
+    </Tooltip.Content>
+</Tooltip.Root>
+
+<style>
+    .copyable-text {
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        padding: 0;
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+        transition: color 0.15s ease;
+        position: relative;
+    }
+
+    .copyable-text.truncated {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        display: block;
+    }
+
+    .copyable-text:hover {
+        color: #79ecb7;
+    }
+
+    .copyable-text.copied {
+        color: #10b981;
+        animation: pulse 0.3s ease;
+    }
+
+    @keyframes pulse {
+        0%, 100% {
+            transform: scale(1);
+        }
+        50% {
+            transform: scale(1.02);
+        }
+    }
+</style>
+

--- a/src/lib/components/ui/copyable-text/copyable-text.svelte
+++ b/src/lib/components/ui/copyable-text/copyable-text.svelte
@@ -1,0 +1,89 @@
+<script>
+    import * as Tooltip from "$src/lib/components/ui/tooltip";
+    import { success } from "$src/modules/utils/toast.svelte.js";
+
+    let { 
+        value = '',
+        truncate = true,
+        showToast = false,
+        successMessage = 'Copied to clipboard'
+    } = $props();
+
+    let copied = $state(false);
+
+    async function copyToClipboard() {
+        if (!value || value === '-') return;
+        
+        try {
+            await navigator.clipboard.writeText(value);
+            copied = true;
+            if (showToast) {
+                success(successMessage);
+            }
+            
+            setTimeout(() => {
+                copied = false;
+            }, 1000);
+        } catch (err) {
+            console.error('Failed to copy:', err);
+        }
+    }
+</script>
+
+<Tooltip.Root>
+    <Tooltip.Trigger>
+        <button 
+            class="copyable-text" 
+            class:truncated={truncate}
+            class:copied={copied}
+            onclick={copyToClipboard}
+            type="button"
+        >
+            {value || '-'}
+        </button>
+    </Tooltip.Trigger>
+    <Tooltip.Content>
+        <p>{copied ? '✓ Copied!' : value || '-'}</p>
+    </Tooltip.Content>
+</Tooltip.Root>
+
+<style>
+    .copyable-text {
+        width: 100%;
+        background: none;
+        border: none;
+        color: inherit;
+        padding: 0;
+        font: inherit;
+        text-align: left;
+        cursor: pointer;
+        transition: color 0.15s ease;
+        position: relative;
+    }
+
+    .copyable-text.truncated {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        display: block;
+    }
+
+    .copyable-text:hover {
+        color: #79ecb7;
+    }
+
+    .copyable-text.copied {
+        color: #10b981;
+        animation: pulse 0.3s ease;
+    }
+
+    @keyframes pulse {
+        0%, 100% {
+            transform: scale(1);
+        }
+        50% {
+            transform: scale(1.02);
+        }
+    }
+</style>
+

--- a/src/lib/components/ui/copyable-text/index.js
+++ b/src/lib/components/ui/copyable-text/index.js
@@ -1,0 +1,8 @@
+import Root from "./copyable-text.svelte";
+
+export {
+    Root,
+    //
+    Root as CopyableText,
+};
+

--- a/src/pages/Home/IdsViewer.svelte
+++ b/src/pages/Home/IdsViewer.svelte
@@ -3,6 +3,7 @@
     import { getAuditReportById, downloadAuditReport } from "$src/modules/api/api.svelte.js";
     import { error, success } from "$src/modules/utils/toast.svelte.js";
     import * as Tooltip from "$src/lib/components/ui/tooltip";
+    import * as CopyableText from "$src/lib/components/ui/copyable-text";
 
     let activeDocument = $derived(IDS.Module.activeDocument ? IDS.Module.documents[IDS.Module.activeDocument] : null);
     let documentState = $derived(IDS.Module.activeDocument ? IDS.Module.states[IDS.Module.activeDocument] : null);
@@ -346,48 +347,12 @@
                                                                                     <tbody>
                                                                                         {#each reqAuditData.passed_entities.slice(0, 10) as entity}
                                                                                             <tr>
-                                                                                                <td>{entity.class}</td>
-                                                                                                <td>{entity.predefined_type || '-'}</td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.name || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.name || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root delayDuration={0}>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.description || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.description || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.global_id || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.global_id || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.tag || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.tag || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
+                                                                                                <td><CopyableText.Root value={entity.class} /></td>
+                                                                                                <td><CopyableText.Root value={entity.predefined_type || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.name || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.description || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.global_id || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.tag || '-'} /></td>
                                                                                             </tr>
                                                                                         {/each}
                                                                                         {#if reqAuditData.passed_entities.length > 10}
@@ -422,58 +387,13 @@
                                                                                     <tbody>
                                                                                         {#each reqAuditData.failed_entities.slice(0, 10) as entity}
                                                                                             <tr>
-                                                                                                <td>{entity.class}</td>
-                                                                                                <td>{entity.predefined_type || '-'}</td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.name || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.name || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root delayDuration={0}>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.description || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.description || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root delayDuration={0}>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.reason || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.reason || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.global_id || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.global_id || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
-                                                                                                <td>
-                                                                                                    <Tooltip.Root>
-                                                                                                        <Tooltip.Trigger>
-                                                                                                            <div class="truncated-text">{entity.tag || '-'}</div>
-                                                                                                        </Tooltip.Trigger>
-                                                                                                        <Tooltip.Content>
-                                                                                                            <p>{entity.tag || '-'}</p>
-                                                                                                        </Tooltip.Content>
-                                                                                                    </Tooltip.Root>
-                                                                                                </td>
+                                                                                                <td><CopyableText.Root value={entity.class} /></td>
+                                                                                                <td><CopyableText.Root value={entity.predefined_type || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.name || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.description || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.reason || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.global_id || '-'} /></td>
+                                                                                                <td><CopyableText.Root value={entity.tag || '-'} /></td>
                                                                                             </tr>
                                                                                         {/each}
                                                                                         {#if reqAuditData.failed_entities.length > 10}


### PR DESCRIPTION
Adds a reusable `CopyableText` component that enables click-to-copy functionality for all table cell values in the entity tables (passed and failed elements).

**Changes:**
- New component: `CopyableText` with hover effects and clipboard integration
- Applied to all entity table columns (Class, PredefinedType, Name, Description, GlobalId, Tag, Warning)
- Toast notification shows copied value on second row

**UX:**
- Hover: text turns green to indicate clickability
- Click: copies value to clipboard with visual feedback
- Toast displays confirmation with the copied value